### PR TITLE
CentOS6 compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ logger.o: logger.cpp logger.h
 passthrough.so: passthrough.o functions.o logger.o config.o sea.o
 	gcc -shared passthrough.o functions.o logger.o config.o sea.o ${debug_opts} -o passthrough.so -ldl -lpthread -lstdc++ -liniparser
 test_custom.o: tests/test_custom.cpp passthrough.o sea.o config.o logger.o
-	gcc ${debug_opts} -std=c++11 -Wall -fPIC tests/test_custom.cpp passthrough.o sea.o config.o logger.o -o tests/test_custom -lstdc++ -liniparser -ldl -lgtest -lpthread 
+	gcc ${debug_opts} -std=c++0x -Wall -fPIC tests/test_custom.cpp passthrough.o sea.o config.o logger.o -o tests/test_custom -lstdc++ -liniparser -ldl -lgtest -lpthread 
 test: test_custom.o
 clean:
 	\rm -f logger.o functions.o passthrough.o config.o sea.o passthrough.so *.gcda *.gcov *.gcno tests/test_custom

--- a/functions.cpp
+++ b/functions.cpp
@@ -245,6 +245,8 @@ extern "C" {
                 return ((funcptr_opendir)libc_opendir)(passpath);
 
             SEA_DIR *sd = new SEA_DIR;
+            strcpy(sd->type, "seadir");
+            sd->curr_index = 0;
             sd->dirnames = (char**) malloc(sizeof(char*) * sea_conf.n_sources * PATH_MAX);
             sd->other_dirp = (DIR**) malloc(sizeof(DIR*) * sea_conf.n_sources - 1);
 

--- a/sea.h
+++ b/sea.h
@@ -11,7 +11,6 @@
 #include <limits.h>
 #include <set>
 #include <string>
-#include <string.h>
 #include <dirent.h>
 
 extern int sea_internal;

--- a/sea.h
+++ b/sea.h
@@ -11,6 +11,7 @@
 #include <limits.h>
 #include <set>
 #include <string>
+#include <string.h>
 #include <dirent.h>
 
 extern int sea_internal;
@@ -27,9 +28,9 @@ void initialize_sea_if_necessary();
 struct SEA_DIR {
     DIR* dirp;
     DIR** other_dirp;
-    char type[7] = "seadir"; // mostly useless. only used in closedir to ensure struct type is right
+    char type[7]; // mostly useless. only used in closedir to ensure struct type is right
     char** dirnames;
-    int curr_index = 0;
+    int curr_index;
 };
 
 #endif

--- a/tests/test_custom.cpp
+++ b/tests/test_custom.cpp
@@ -11,7 +11,8 @@ TEST(Passthrough, GetCanonical) {
 
     const char paths[6][PATH_MAX] = { "mount", "./mount/subdir", "../mount/", "/dev/shm/tmp", "/", NULL };
 
-    for(auto path: paths){
+    for(int i = 0 ; i < 6 ; i++){
+        const char * path = paths[i];
         char* actualpath;
         char* expected = (char*) malloc(sizeof(char*) * PATH_MAX);
     
@@ -66,8 +67,8 @@ TEST(Passthrough, CheckIfSeaPath) {
 
     realpath("mount", path);
 
-    int i = 0;
-    for (auto op: oldpaths) {
+    for (int i = 0 ; i < 4 ; i++) {
+        char * op = oldpaths[i];
         // need to reinitialize each time otherwise may retain tail of previous value
         char passpath[PATH_MAX];
         realpath("source", passpath);
@@ -84,7 +85,6 @@ TEST(Passthrough, CheckIfSeaPath) {
             ASSERT_EQ(res, 0);
 
         ASSERT_STREQ(passpath, expected);
-        ++i;
     }
 }
 


### PR DESCRIPTION
The default gcc CentOS 6 doesn't support C++11. This removes C++11 features, including:
* Initialization in structs (SEA_DIR), now initialized upon creation
* For iterations on arrays

An alternative to these fixes would be to install a C++11 compiler on CentOS6, but I think it would also introduce runtime dependencies and I don't think we want that. See https://edwards.sdsu.edu/research/c11-on-centos-6/

As discussed, feel free to remove support for CentOS6 if you don't want to carry this weight further. 